### PR TITLE
make layer url inputs 'clearable'

### DIFF
--- a/modules/svg/geoservice.js
+++ b/modules/svg/geoservice.js
@@ -656,7 +656,7 @@ export function svgGeoService(projection, context, dispatch) {
         }
         if (downloadMax && url.indexOf('where') === -1) {
             // if there is no spatial query, need a SQL query here
-            url += '&where=1>0';
+            url += 'where=1>0';
         }
         if (url.indexOf('outSR') === -1) {
             url += '&outSR=4326';


### PR DESCRIPTION
* removed unnecessary ampersand inserted prior to first query parameter
* ensured that users _cannot_ fetch "Shape", "Shape_Length" or "Shape_Area" fields
* added a warning when a url is provided that isn't recognized as a valid geoservice
* introduced logic to hide layer preview metadata when the url input is cleared

resolves #28 (_without_ bonus points)