### PR TITLE
add mandatory, user editable discussion tag to changeset

### DIFF
--- a/modules/behavior/hash.js
+++ b/modules/behavior/hash.js
@@ -51,9 +51,9 @@ export function behaviorHash(context) {
         newParams.map = zoom.toFixed(2) +
             '/' + center[1].toFixed(precision) +
             '/' + center[0].toFixed(precision);
-        
+
         /*
-        var gsLayer = context.layers().layer('geoservice').originalURL;
+        var gsLayer = context.layers().layer('geoservice').layerUrl;
         if (gsLayer) {
             q.geoservice = gsLayer;
         }

--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -16,7 +16,7 @@ export function coreHistory(context) {
         lock = utilSessionMutex('lock'),
         duration = 150,
         checkpoints = {},
-        stack, index, tree;
+        stack, index, tree, source;
 
 
     // internal _act, accepts list of actions and eased time
@@ -40,7 +40,8 @@ export function coreHistory(context) {
         return {
             graph: graph,
             annotation: annotation,
-            imageryUsed: imageryUsed
+            imageryUsed: imageryUsed,
+            source: source
         };
     }
 
@@ -285,6 +286,15 @@ export function coreHistory(context) {
             }
         },
 
+        source: function(sourceUrl) {
+            if (sourceUrl) {
+                source = sourceUrl;
+                return history;
+            } else {
+                return source;
+            }
+        },
+
 
         // save the current history state
         checkpoint: function(key) {
@@ -414,6 +424,7 @@ export function coreHistory(context) {
                 if (deleted.length) x.deleted = deleted;
                 if (i.imageryUsed) x.imageryUsed = i.imageryUsed;
                 if (i.annotation) x.annotation = i.annotation;
+                if (i.source) x.source = i.source;
 
                 return x;
             });
@@ -516,7 +527,8 @@ export function coreHistory(context) {
                     return {
                         graph: coreGraph(stack[0].graph).load(entities),
                         annotation: d.annotation,
-                        imageryUsed: d.imageryUsed
+                        imageryUsed: d.imageryUsed,
+                        source: d.source
                     };
                 });
 

--- a/modules/modes/save.js
+++ b/modules/modes/save.js
@@ -34,14 +34,14 @@ export function modeSave(context) {
     var mode = {
         id: 'save'
     };
-    
+
     if (d3.select('input[name="approvalProcess"]:checked').property('value') === 'individual') {
         // when clicking the save button, filter out entities which were not approved manually
         var deletions = [];
         _.map(window.importedEntities, function(entity) {
             try {
                 if ((entity.approvedForEdit !== 'approved' && entity.approvedForEdit !== 'unchanged') && context.entity(entity.id)) {
-                    deletions.push(entity.id); 
+                    deletions.push(entity.id);
                 }
             } catch (e) {
                 // entity was already deleted, can't be removed here

--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -92,8 +92,9 @@ export function rendererBackground(context) {
             .forEach(function (d) { imageryUsed.push(d.source().imageryUsed()); });
 
         var gsLayer = context.layers().layer('geoservice');
-        if (gsLayer && gsLayer.enabled() && gsLayer.hasData()) {
+        if (gsLayer && gsLayer.hasData()) {
             imageryUsed.push('GeoService');
+            context.history().source(gsLayer.layerUrl);
         }
 
         var gpx = context.layers().layer('gpx');
@@ -272,7 +273,7 @@ export function rendererBackground(context) {
                 background.toggleOverlayLayer(overlay);
             }
         });
-        
+
         /*
         if (q.geoservice) {
             setTimeout(function() {

--- a/modules/svg/geoservice.js
+++ b/modules/svg/geoservice.js
@@ -637,8 +637,8 @@ export function svgGeoService(projection, context, dispatch) {
     };
 
     drawGeoService.url = function(true_url, downloadMax) {
-        if (!this.originalURL) {
-            this.originalURL = true_url;
+        if (!this.layerUrl) {
+            drawGeoService.layerUrl = true_url;
         }
 
         var fmt = drawGeoService.format() || 'json';
@@ -700,7 +700,7 @@ export function svgGeoService(projection, context, dispatch) {
         }
 
         var that = this;
-        console.log('final GeoService URL: ' + url);
+        // console.log('final GeoService URL: ' + url);
         d3.text(url, function(err, data) {
             if (err) {
                 console.log('GeoService URL did not load');

--- a/modules/ui/map_data.js
+++ b/modules/ui/map_data.js
@@ -502,6 +502,7 @@ export function uiMapData(context) {
                 content.append('h3')
                     .text('Import from a GeoService by URL');
 
+
                 var body = content.append('div')
                     .attr('class', 'body');
 
@@ -540,7 +541,7 @@ export function uiMapData(context) {
                                     .text('The url provided not recognized as a valid GeoService');
                                 unrecognizedLabel.classed('hide', false);
                                 return;
-                            } 
+                            }
                         }
 
                         // if it just ends /0, we need to keep /0 around
@@ -831,6 +832,7 @@ export function uiMapData(context) {
 
         function editGeoService() {
             // window allows user to enter a GeoService layer
+
             d3.event.preventDefault();
             toggle();
         }

--- a/modules/ui/save.js
+++ b/modules/ui/save.js
@@ -7,7 +7,6 @@ import { uiCmd } from './cmd';
 import { uiTooltipHtml } from './tooltipHtml';
 import { tooltip } from '../util/tooltip';
 
-
 export function uiSave(context) {
     var history = context.history(),
         key = uiCmd('⌘S');


### PR DESCRIPTION
i noticed today that `;Geoservice` was no longer being appended to the `imagery_used` changeset tag. i _think_ that regression is the result of #29

this PR:
* handles the above (i'm just skipping the `gsLayer.enabled()` check, happy to discuss other options)
* adds a new non-editable `source` tag and automatically inserts the layer url
* adds a new mandatory, editable `import_discussion` tag

the last two are based on the feedback here https://github.com/openstreetmap/iD/issues/4164#issuecomment-317789494
